### PR TITLE
Add Node helper to register Blockforge workflow in n8n

### DIFF
--- a/docs/n8n-workflow.md
+++ b/docs/n8n-workflow.md
@@ -1,0 +1,56 @@
+# Automating Blockforge builds with n8n
+
+This guide demonstrates how to register a reusable n8n workflow from Node.js that triggers
+external build infrastructure for Blockforge.
+
+The workflow created by the helper script contains three nodes:
+
+1. **Manual Trigger** – lets you fire the automation directly from the n8n UI.
+2. **Prepare Build Context** – a Function node that emits the command line to execute.
+3. **Trigger Build Webhook** – posts the command payload to a webhook (for example, a self-hosted
+   build runner that translates the payload into PowerShell commands like `tools/build.ps1 -Config Debug`).
+
+The workflow stays inactive so it can be wired into more complex scenarios such as scheduled or
+Git-triggered automation.
+
+## Prerequisites
+
+- A running n8n instance (self-hosted or cloud) with an API key enabled.
+- Node.js 18 or later to run the helper script.
+
+## Registering the workflow
+
+```bash
+# Export the API key n8n generated for you
+export N8N_API_KEY=your-n8n-api-key
+
+# Optionally change the host if n8n is not on localhost:5678
+export N8N_HOST=https://automation.example.com
+
+# Provide the webhook endpoint that will accept build requests
+node tools/n8n/register-blockforge-workflow.mjs --webhook=https://ci.example.com/build
+```
+
+The script performs an upsert:
+
+- If a workflow named **Blockforge Build Dispatcher** does not exist, it is created.
+- If it already exists, the definition is updated in-place so the automation stays in sync with the
+  repository version.
+
+You can customize the workflow name with `--name="Custom Workflow"` and override the host or API key via
+command line arguments instead of environment variables.
+
+## Using the workflow output
+
+The final HTTP Request node posts a JSON payload to the webhook you provide. It uses the structure below:
+
+```json
+{
+  "command": "tools/build.ps1 -Config Debug",
+  "project": "Blockforge"
+}
+```
+
+Adapt your receiver to translate this payload into the appropriate build, test, or deployment actions.
+Because the workflow definition is stored as code, you can version it along with the rest of the
+Blockforge repository and reuse it across n8n environments.

--- a/tools/n8n/register-blockforge-workflow.mjs
+++ b/tools/n8n/register-blockforge-workflow.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+const args = process.argv.slice(2);
+const options = {};
+for (const arg of args) {
+  const [key, value] = arg.split('=');
+  if (key.startsWith('--')) {
+    options[key.slice(2)] = value ?? true;
+  }
+}
+
+const host = options.host ?? process.env.N8N_HOST ?? 'http://localhost:5678';
+const apiKey = options['api-key'] ?? process.env.N8N_API_KEY;
+if (!apiKey) {
+  console.error('Missing n8n API key. Provide via --api-key=<key> or N8N_API_KEY env variable.');
+  process.exit(1);
+}
+
+const workflowName = options.name ?? 'Blockforge Build Dispatcher';
+
+const workflowPayload = {
+  name: workflowName,
+  active: false,
+  nodes: [
+    {
+      parameters: {},
+      id: '1',
+      name: 'Manual Trigger',
+      type: 'n8n-nodes-base.manualTrigger',
+      typeVersion: 1,
+      position: [260, 300],
+    },
+    {
+      parameters: {
+        functionCode: `return [{\n  buildCommand: 'tools/build.ps1 -Config Debug',\n  notes: 'Invoke from a Windows shell configured for vcpkg toolchain.',\n}];`,
+      },
+      id: '2',
+      name: 'Prepare Build Context',
+      type: 'n8n-nodes-base.function',
+      typeVersion: 1,
+      position: [540, 300],
+    },
+    {
+      parameters: {
+        url: options.webhook ?? 'http://localhost:3000/build',
+        method: 'POST',
+        jsonParameters: true,
+        options: {},
+        bodyParametersJson: `{"command":"tools/build.ps1 -Config Debug","project":"Blockforge"}`,
+      },
+      id: '3',
+      name: 'Trigger Build Webhook',
+      type: 'n8n-nodes-base.httpRequest',
+      typeVersion: 2,
+      position: [820, 300],
+    },
+  ],
+  connections: {
+    'Manual Trigger': {
+      main: [
+        [
+          {
+            node: 'Prepare Build Context',
+            type: 'main',
+            index: 0,
+          },
+        ],
+      ],
+    },
+    'Prepare Build Context': {
+      main: [
+        [
+          {
+            node: 'Trigger Build Webhook',
+            type: 'main',
+            index: 0,
+          },
+        ],
+      ],
+    },
+  },
+};
+
+const headers = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'X-N8N-API-KEY': apiKey,
+};
+
+const fetchJson = async (url, init = {}) => {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Request failed (${response.status} ${response.statusText}): ${detail}`);
+  }
+  return response.json();
+};
+
+const baseUrl = host.replace(/\/$/, '') + '/api/v1';
+
+let existingWorkflow;
+try {
+  const { data: workflows } = await fetchJson(`${baseUrl}/workflows`, {
+    headers,
+  });
+  existingWorkflow = workflows.find((wf) => wf.name === workflowName);
+} catch (error) {
+  console.error('Unable to query existing workflows from n8n.');
+  console.error(error.message);
+  process.exit(1);
+}
+
+try {
+  if (existingWorkflow) {
+    const updated = await fetchJson(`${baseUrl}/workflows/${existingWorkflow.id}`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ ...workflowPayload, id: existingWorkflow.id }),
+    });
+    console.log(`Updated existing workflow "${updated.name}" (id=${updated.id}).`);
+  } else {
+    const created = await fetchJson(`${baseUrl}/workflows`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(workflowPayload),
+    });
+    console.log(`Created workflow "${created.name}" (id=${created.id}).`);
+  }
+} catch (error) {
+  console.error('Failed to upsert workflow.');
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a Node.js script that upserts a Blockforge build workflow through the n8n REST API
- document how to configure and run the helper from a local development environment

## Testing
- not run (automation helper only calls external n8n instance)

------
https://chatgpt.com/codex/tasks/task_b_68f10a15e00483238762047bd535e7c8